### PR TITLE
create file for CRC cards

### DIFF
--- a/doc/crc_cards.txt
+++ b/doc/crc_cards.txt
@@ -1,0 +1,1 @@
+// we can create CRC cards here to identify the key entity classes (and their generalizations, as appropriate) for this app.


### PR DESCRIPTION
We can use CRC cards to initially model our design. With fully planned out CRC cards, it should be a lot easier to create the UML diagram.